### PR TITLE
fix: Do not indent list items

### DIFF
--- a/lib/prawn_html/tags/li.rb
+++ b/lib/prawn_html/tags/li.rb
@@ -5,9 +5,6 @@ module PrawnHtml
     class Li < Tag
       ELEMENTS = [:li].freeze
 
-      INDENT_OL = -12
-      INDENT_UL = -6
-
       def block?
         true
       end
@@ -18,19 +15,11 @@ module PrawnHtml
         @before_content_once = @counter ? "#{@counter}. " : "#{@symbol} "
       end
 
-      def block_styles
-        super.tap do |bs|
-          bs[:indent_paragraphs] = @indent
-        end
-      end
-
       def on_context_add(_context)
         case parent.class.to_s
         when 'PrawnHtml::Tags::Ol'
-          @indent = INDENT_OL
           @counter = (parent.counter += 1)
         when 'PrawnHtml::Tags::Ul'
-          @indent = INDENT_UL
           @symbol = parent.styles[:list_style_type] || '&bullet;'
         end
       end


### PR DESCRIPTION
Currently, the first line of a list item is indented for both ordered and unordered lists. This is something we want to avoid.

These changes should fix that.