### PR TITLE
Add parent counters for li tags to handle counters for nested lists

### DIFF
--- a/lib/prawn_html/tags/li.rb
+++ b/lib/prawn_html/tags/li.rb
@@ -5,6 +5,8 @@ module PrawnHtml
     class Li < Tag
       ELEMENTS = [:li].freeze
 
+      attr_reader :counter
+
       def block?
         true
       end

--- a/lib/prawn_html/tags/li.rb
+++ b/lib/prawn_html/tags/li.rb
@@ -21,7 +21,7 @@ module PrawnHtml
         case parent.class.to_s
         when 'PrawnHtml::Tags::Ol'
           @counter = (parent.counter += 1)
-          @parent_counters = context.select { |element| element.tag == :li && element != self }.map(&:counter)
+          @parent_counters = context.filter_map { |element| element.counter if element.tag == :li && element != self }
         when 'PrawnHtml::Tags::Ul'
           @symbol = parent.styles[:list_style_type] || '&bullet;'
         end

--- a/lib/prawn_html/tags/li.rb
+++ b/lib/prawn_html/tags/li.rb
@@ -12,16 +12,25 @@ module PrawnHtml
       def before_content
         return if @before_content_once
 
-        @before_content_once = @counter ? "#{@counter}. " : "#{@symbol} "
+        @before_content_once = @counter ? "#{formatted_counter} " : "#{@symbol} "
       end
 
-      def on_context_add(_context)
+      def on_context_add(context)
         case parent.class.to_s
         when 'PrawnHtml::Tags::Ol'
           @counter = (parent.counter += 1)
+          @parent_counters = context.select { |element| element.tag == :li && element != self }.map(&:counter)
         when 'PrawnHtml::Tags::Ul'
           @symbol = parent.styles[:list_style_type] || '&bullet;'
         end
+      end
+
+      private
+
+      def formatted_counter
+        return "#{@counter}." if @parent_counters.blank?
+
+        (@parent_counters + [@counter]).compact.join('.')
       end
     end
   end


### PR DESCRIPTION
With this change, we define the lists `parent_counters` as the counters from the other lists higher up in the hierarchy. 

The purpose of this is to be able to handle numbering of nested lists, like these:
![Screenshot 2023-12-05 at 11 35 55](https://github.com/qasase/prawn-html/assets/39914076/516ce48f-f925-4ef8-b58d-a930bd4c8e48)

